### PR TITLE
feat: added condiition to check for text nodes with empty white space

### DIFF
--- a/src/fromRedactor.tsx
+++ b/src/fromRedactor.tsx
@@ -163,7 +163,7 @@ export const fromRedactor = (el: any, options?:IHtmlToJsonOptions) : IAnyObject 
   // If node is text node
   if (el.nodeType === 3) {
     if (whiteCharPattern.test(el.textContent)) return null
-    if (["TABLE", "THEAD", "TBODY", "TR"].includes(el?.parentElement?.nodeName ?? "") && (el.textContent as string).trim().length === 0) return null
+    if (["TABLE", "THEAD", "TBODY", "TR"].includes(el?.parentElement?.nodeName ?? "") && el?.textContent?.trim?.()?.length === 0) return null
     if (el.textContent === '\n') {
       return null
     }

--- a/src/fromRedactor.tsx
+++ b/src/fromRedactor.tsx
@@ -163,7 +163,7 @@ export const fromRedactor = (el: any, options?:IHtmlToJsonOptions) : IAnyObject 
   // If node is text node
   if (el.nodeType === 3) {
     if (whiteCharPattern.test(el.textContent)) return null
-    if ((el.textContent as string).trim().length === 0) return null
+    if (["TABLE", "THEAD", "TBODY", "TR"].includes(el?.parentElement?.nodeName ?? "") && (el.textContent as string).trim().length === 0) return null
     if (el.textContent === '\n') {
       return null
     }

--- a/src/fromRedactor.tsx
+++ b/src/fromRedactor.tsx
@@ -160,8 +160,10 @@ const traverseChildAndWarpChild = (children: Array<Object>) => {
 
 const whiteCharPattern = /^[\s ]{2,}$/
 export const fromRedactor = (el: any, options?:IHtmlToJsonOptions) : IAnyObject | null => {
+  // If node is text node
   if (el.nodeType === 3) {
     if (whiteCharPattern.test(el.textContent)) return null
+    if ((el.textContent as string).trim().length === 0) return null
     if (el.textContent === '\n') {
       return null
     }

--- a/test/fromRedactor.test.ts
+++ b/test/fromRedactor.test.ts
@@ -270,3 +270,38 @@ describe('getNestedValueIfAvailable', () => {
     });
 
 });
+describe("CS-41001", () =>{
+    test("should not add fragment for text nodes having white spaces", () => {
+        const dom = new JSDOM();
+        const document = dom.window.document;
+        const body = document.createElement("body");
+        const td1 = document.createElement("td");
+        const td2 = document.createElement("td");
+        const tr = document.createElement("tr");
+        const text = document.createTextNode(` `)
+        td1.textContent = "Hello";
+        td2.textContent = "World";
+        tr.appendChild(td1);
+        tr.append(text)
+        tr.appendChild(td2);
+        body.append(tr)
+        const jsonValue = fromRedactor(body);
+        expect(jsonValue).toStrictEqual({"type":"doc","uid":"uid","attrs":{},"children":[{"type":"tr","attrs":{},"uid":"uid","children":[{"type":"td","attrs":{},"uid":"uid","children":[{"text":"Hello"}]},{"type":"td","attrs":{},"uid":"uid","children":[{"text":"World"}]}]}]})
+    })
+    test("should add fragment for text nodes between block nodes", () => {
+        const dom = new JSDOM();
+        const document = dom.window.document;
+        const body = document.createElement("body");
+        const p1 = document.createElement("p");
+        const p2 = document.createElement("p");
+        const text = document.createTextNode(` beautiful `)
+        p1.textContent = "Hello";
+        p2.textContent = "World";
+        body.appendChild(p1);
+        body.append(text)
+        body.appendChild(p2);
+        const jsonValue = fromRedactor(body);
+        expect(jsonValue).toStrictEqual({"type":"doc","uid":"uid","attrs":{},"children":[{"type":"p","attrs":{},"uid":"uid","children":[{"text":"Hello"}]},{"type":"fragment","attrs":{},"uid":"uid","children":[{"text":" beautiful "}]},{"type":"p","attrs":{},"uid":"uid","children":[{"text":"World"}]}]})
+    })
+})
+


### PR DESCRIPTION
**Issue:**
Empty whitespace between nodes (because of formatting) was converted to text nodes having only whitespace, since these text nodes were between block nodes they were wrapped in fragment node, causing extra fragment node to be inserted in JSON.  
**Solution:**
Added condition to check for text nodes with empty white space using trim and length which are present inside table, tbody, thead, tr