### PR TITLE
fix: skip text wrappers when mark value is falsy

### DIFF
--- a/src/toRedactor.tsx
+++ b/src/toRedactor.tsx
@@ -48,7 +48,7 @@ export const toRedactor = (jsonValue: any,options?:IJsonToHtmlOptions) : string 
       text = text.replace(/\n/g, '<br/>')
     }
     Object.entries(jsonValue).forEach(([key, value]) => {
-      if(localTextWrappers.hasOwnProperty(key)){
+      if(localTextWrappers.hasOwnProperty(key) && value){
         text = localTextWrappers[key](text,value)
       }
     })

--- a/test/toRedactor.test.ts
+++ b/test/toRedactor.test.ts
@@ -104,6 +104,28 @@ describe("Testing json to html conversion", () => {
         expect(htmlValue).toBe(expectedValue["inline-classname-and-id"].html)
     })
 
+    describe("Falsy text marks", () => {
+        it("does not wrap text when bold/italic/underline are false", () => {
+            const jsonValue = [{
+                type: "p",
+                attrs: {},
+                children: [{ text: "Plain text", bold: false, italic: false, underline: false }]
+            }]
+            const htmlValue = toRedactor({ type: "doc", attrs: {}, children: jsonValue })
+            expect(htmlValue).toBe("<p>Plain text</p>")
+        })
+
+        it("wraps only the marks whose value is true", () => {
+            const jsonValue = [{
+                type: "p",
+                attrs: {},
+                children: [{ text: "Mixed", bold: true, italic: false, underline: true }]
+            }]
+            const htmlValue = toRedactor({ type: "doc", attrs: {}, children: jsonValue })
+            expect(htmlValue).toBe("<p><u><strong>Mixed</strong></u></p>")
+        })
+    })
+
     describe("Nested attrs", () => {
 
         test("should have stringified attrs for nested json", () => {


### PR DESCRIPTION
## Summary

Fixes a bug in `toRedactor` where text marks (e.g. `bold`, `italic`, `underline`) were applied even when their value was explicitly `false`. Previously, the code only checked whether the mark key existed on the node, not whether its value was truthy — so a child like `{ text: "foo", bold: false }` would still be wrapped in `<strong>`.

## Changes

- **`src/toRedactor.tsx`**: Added a truthiness check so a text wrapper is only applied when the mark's value is truthy:

  ```diff
  - if (localTextWrappers.hasOwnProperty(key)) {
  + if (localTextWrappers.hasOwnProperty(key) && value) {